### PR TITLE
Add a Nix derivation for working with tmk_keyboard

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,49 @@
+# A Nix shell for tmk_keyboard.
+# Based on the shell for qmk/qmk_firmware:
+# https://github.com/qmk/qmk_firmware/blob/master/shell.nix
+
+with import <nixpkgs> {
+  config = {
+    allowUnsupportedSystem = true;
+  };
+}; 
+
+let
+  avrbinutils = pkgsCross.avr.buildPackages.binutils;
+  avrlibc = pkgsCross.avr.libcCross;
+
+  avr_incflags = [
+    "-isystem ${avrlibc}/avr/include"
+    "-B${avrlibc}/avr/lib/avr5"
+    "-L${avrlibc}/avr/lib/avr5"
+    "-B${avrlibc}/avr/lib/avr35"
+    "-L${avrlibc}/avr/lib/avr35"
+    "-B${avrlibc}/avr/lib/avr51"
+    "-L${avrlibc}/avr/lib/avr51"
+  ];
+
+  avrgcc = pkgsCross.avr.buildPackages.gcc.overrideAttrs (oldAttrs: rec {
+    name = "avr-gcc-8.1.0";
+    src = fetchurl {
+      url = "mirror://gcc/releases/gcc-8.1.0/gcc-8.1.0.tar.xz";
+      sha256 = "0lxil8x0jjx7zbf90cy1rli650akaa6hpk8wk8s62vk2jbwnc60x";
+    };
+  });
+in 
+
+stdenv.mkDerivation {
+  name = "tmk_keyboard";
+
+  buildInputs = [
+    diffutils
+    dfu-programmer
+    dfu-util
+    avrbinutils
+    avrgcc
+    avrlibc
+    avrdude
+  ];
+
+  CFLAGS = avr_incflags;
+  ASFLAGS = avr_incflags;
+}

--- a/tmk_core/doc/build.md
+++ b/tmk_core/doc/build.md
@@ -14,6 +14,7 @@ Download and Install
 
 If you use PJRC Teensy you don't need step 2 and 3 above, just get [Teensy loader][teensy-loader].
 
+If you use NixOS or the Nix package manager, just run `nix-shell`.
 
 ### 2. Download source
 You can find firmware source at github:


### PR DESCRIPTION
Background: [Nix](https://nixos.org/nix/) is a package manager which, among other things, allows for packages to be installed in a single shell's environment. It's the package manager of the NixOS Linux distribution, but also sees some use outside of that ecosystem. Generally, Nix users avoid installing build tools globally and instead prefer to spawn temporary shells which contain the tools they need for a particular project.

This patch adds a Nix derivation (basically a package description) which makes the `avr-gcc` toolchain and `dfu-programmer` available on the user's `$PATH`. It allows one to run `nix-shell` and proceed to immediately begin building keyboard firmware, essentially skipping the ["Download & Install"](https://github.com/tmk/tmk_keyboard/blob/master/tmk_core/doc/build.md#download-and-install) step of the build guide.

I based this off the [Nix derivation](https://github.com/qmk/qmk_firmware/blob/master/shell.nix) `qmk_firmware` uses. It works well enough to install new firmware to my HHKB Pro JP with the USB controller, but I did not test it for any other models. It also doesn't support other flashing methods besides `dfu-programmer`.